### PR TITLE
Load credentials from .aws/config and .aws/credentials

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -43,6 +43,9 @@ func LoadAWSCredentials(profileName string) (aws.Auth, aws.Region, error) {
 	if auth, _ := aws.EnvAuth(); isValidAuth(auth) {
 		awsAuth = auth
 	}
+	if isValidAuth(awsAuth) && isValidRegion(awsRegion) {
+		return awsAuth, awsRegion, nil
+	}
 
 	// 2. from File (~/.aws/config, ~/.aws/credentials)
 	if f := os.Getenv("AWS_CONFIG_FILE"); f != "" {
@@ -68,6 +71,9 @@ func LoadAWSCredentials(profileName string) (aws.Auth, aws.Region, error) {
 			awsRegion = region
 		}
 	}
+	if isValidAuth(awsAuth) && isValidRegion(awsRegion) {
+		return awsAuth, awsRegion, nil
+	}
 
 	// 3. from IAM Role
 	cred, err := aws.GetInstanceCredentials()
@@ -78,7 +84,6 @@ func LoadAWSCredentials(profileName string) (aws.Auth, aws.Region, error) {
 			awsAuth = *auth
 		}
 	}
-
 	if isValidAuth(awsAuth) && isValidRegion(awsRegion) {
 		return awsAuth, awsRegion, nil
 	}

--- a/aws.go
+++ b/aws.go
@@ -1,14 +1,14 @@
 package stretcher
 
 import (
-	"fmt"
-	"io/ioutil"
+	"errors"
 	"log"
 	"os"
-	"strings"
+	"path/filepath"
 	"time"
 
 	"github.com/AdRoll/goamz/aws"
+	ini "github.com/vaughan0/go-ini"
 )
 
 const (
@@ -16,66 +16,95 @@ const (
 	AWSDefaultProfileName = "default"
 )
 
-func LoadAWSConfigFile(fileName string, profileName string) error {
-	if profileName == "" {
-		profileName = "default"
-	}
-
-	f, err := os.Open(fileName)
-	if err != nil {
-		return fmt.Errorf("Cannot open %s %s", fileName, err)
-	}
-	defer f.Close()
-	body, err := ioutil.ReadAll(f)
-	if err != nil {
-		return fmt.Errorf("Cannot read %s %s", fileName, err)
-	}
-
-	profiles := map[string]map[string]string{}
-	currentProfile := ""
-	for _, line := range strings.Split(string(body), "\n") {
-		if strings.Index(line, "[profile ") == 0 {
-			p := strings.Split(line, " ")
-			if len(p) < 2 {
-				continue
-			}
-			currentProfile = strings.Replace(p[1], "]", "", 1)
-		} else if strings.Index(line, "[default]") == 0 {
-			currentProfile = "default"
-		} else if strings.Index(line, "=") != -1 {
-			pair := strings.Split(line, "=")
-			key := strings.Trim(pair[0], " ")
-			val := strings.Trim(pair[1], " ")
-			if _, ok := profiles[currentProfile]; !ok {
-				profiles[currentProfile] = map[string]string{}
-			}
-			profiles[currentProfile][key] = val
-		}
-	}
-	profile, ok := profiles[profileName]
-	if !ok {
-		return fmt.Errorf("profile [%s] not found in %s", profileName, fileName)
-	}
-	AWSAuth = aws.Auth{
-		AccessKey: profile["aws_access_key_id"],
-		SecretKey: profile["aws_secret_access_key"],
-	}
-	if profile["region"] == "" {
-		profile["region"] = AWSDefaultRegionName
-	}
-	AWSRegion = aws.GetRegion(profile["region"])
-	log.Printf("aws_access_key_id=%s", AWSAuth.AccessKey)
-	log.Printf("region=%s", AWSRegion.Name)
-	return nil
+func isValidAuth(auth aws.Auth) bool {
+	return auth.AccessKey != "" && auth.SecretKey != ""
 }
 
-func LoadAWSAuthFromIAMRole() {
+func isValidRegion(region aws.Region) bool {
+	return region.Name != ""
+}
+
+func LoadAWSCredentials(profileName string) (aws.Auth, aws.Region, error) {
+	if profileName == "" {
+		if p := os.Getenv("AWS_DEFAULT_PROFILE"); p != "" {
+			profileName = p
+		} else {
+			profileName = AWSDefaultProfileName
+		}
+	}
+
+	var awsAuth aws.Auth
+	var awsRegion aws.Region
+	if region := os.Getenv("AWS_DEFAULT_REGION"); region != "" {
+		awsRegion = aws.GetRegion(region)
+	}
+
+	// 1. from ENV
+	if auth, _ := aws.EnvAuth(); isValidAuth(auth) {
+		awsAuth = auth
+	}
+
+	// 2. from File (~/.aws/config, ~/.aws/credentials)
+	if f := os.Getenv("AWS_CONFIG_FILE"); f != "" {
+		dir, _ := filepath.Split(f)
+		profile := AWSDefaultProfileName
+		if profileName != AWSDefaultProfileName {
+			profile = "profile " + profileName
+		}
+		auth, region, _ := loadAWSConfigFile(f, profile)
+		if isValidAuth(auth) {
+			awsAuth = auth
+		}
+		if isValidRegion(region) {
+			awsRegion = region
+		}
+
+		cred := filepath.Join(dir, "credentials")
+		auth, region, _ = loadAWSConfigFile(cred, profileName)
+		if isValidAuth(auth) {
+			awsAuth = auth
+		}
+		if isValidRegion(region) {
+			awsRegion = region
+		}
+	}
+
+	// 3. from IAM Role
 	cred, err := aws.GetInstanceCredentials()
 	if err == nil {
 		exptdate, err := time.Parse("2006-01-02T15:04:05Z", cred.Expiration)
 		if err == nil {
 			auth := aws.NewAuth(cred.AccessKeyId, cred.SecretAccessKey, cred.Token, exptdate)
-			AWSAuth = *auth
+			awsAuth = *auth
 		}
 	}
+
+	if isValidAuth(awsAuth) && isValidRegion(awsRegion) {
+		return awsAuth, awsRegion, nil
+	}
+
+	return awsAuth, awsRegion, errors.New("cannot detect valid credentials or region")
+}
+
+func loadAWSConfigFile(fileName string, profileName string) (aws.Auth, aws.Region, error) {
+	var auth aws.Auth
+	var region aws.Region
+
+	conf, err := ini.LoadFile(fileName)
+	if err != nil {
+		return auth, region, err
+	}
+	log.Printf("Loading file %s [%s]", fileName, profileName)
+
+	for key, value := range conf[profileName] {
+		switch key {
+		case "aws_access_key_id":
+			auth.AccessKey = value
+		case "aws_secret_access_key":
+			auth.SecretKey = value
+		case "region":
+			region = aws.GetRegion(value)
+		}
+	}
+	return auth, region, nil
 }

--- a/aws_test.go
+++ b/aws_test.go
@@ -1,38 +1,66 @@
 package stretcher_test
 
 import (
+	"os"
 	"testing"
 
 	"github.com/fujiwara/stretcher"
 )
 
 func TestLoadAWSConfigFile(t *testing.T) {
-	stretcher.LoadAWSConfigFile("test/aws.config", "default")
-	if stretcher.AWSAuth.AccessKey != "DZECFQXRXAPORD3VDEKG" {
+	os.Setenv("AWS_CONFIG_FILE", "test/aws.config")
+
+	auth, region, _ := stretcher.LoadAWSCredentials("")
+	if auth.AccessKey != "DZECFQXRXAPORD3VDEKG" {
 		t.Errorf("access_key mismatch")
 	}
-	if stretcher.AWSAuth.SecretKey != "NEZ5eNlmtE6ZjEQlj/uJpsog2ndjPX+uej1CHMYH" {
+	if auth.SecretKey != "NEZ5eNlmtE6ZjEQlj/uJpsog2ndjPX+uej1CHMYH" {
 		t.Errorf("secret_key mismatch")
 
 	}
-	if stretcher.AWSRegion.Name != "ap-northeast-1" {
+	if region.Name != "ap-northeast-1" {
 		t.Errorf("region mismatch")
 	}
 
-	stretcher.LoadAWSConfigFile("test/aws.config", "dummy")
-	if stretcher.AWSAuth.AccessKey != "AAAAAAAAAAAAAAAAAAAA" {
+	auth, region, _ = stretcher.LoadAWSCredentials("dummy")
+	if auth.AccessKey != "AAAAAAAAAAAAAAAAAAAA" {
 		t.Errorf("access_key mismatch")
 	}
-	if stretcher.AWSAuth.SecretKey != "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" {
+	if auth.SecretKey != "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB" {
 		t.Errorf("secret_key mismatch")
 
 	}
-	if stretcher.AWSRegion.Name != "us-east-1" {
+	if region.Name != "us-east-1" {
 		t.Errorf("region mismatch")
 	}
 
-	err := stretcher.LoadAWSConfigFile("test/aws.config", "not_found")
+	os.Setenv("AWS_CONFIG_FILE", "test/aws.config")
+	auth, region, err := stretcher.LoadAWSCredentials("not_found")
 	if err == nil {
 		t.Error("load not_found profile must be error", err)
+	}
+
+	// split config & crecdentials
+	os.Setenv("AWS_CONFIG_FILE", "test/.aws/config")
+	auth, region, err = stretcher.LoadAWSCredentials("foo")
+	if auth.AccessKey != "foo_key" {
+		t.Errorf("access_key mismatch")
+	}
+	if auth.SecretKey != "foo_secret" {
+		t.Errorf("secret_key mismatch")
+	}
+	if region.Name != "us-west-2" {
+		t.Errorf("region mismatch")
+	}
+
+	auth, region, err = stretcher.LoadAWSCredentials("bar")
+	if auth.AccessKey != "bar_key" {
+		t.Errorf("access_key mismatch")
+	}
+	if auth.SecretKey != "bar_secret" {
+		t.Errorf("secret_key mismatch")
+	}
+	if region.Name != "ap-southeast-1" {
+		t.Errorf("region mismatch")
 	}
 }

--- a/cmd/aws_configure_list/main.go
+++ b/cmd/aws_configure_list/main.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"log"
+
+	"github.com/fujiwara/stretcher"
+)
+
+func main() {
+	var profile string
+	flag.StringVar(&profile, "profile", "", "aws profile name")
+	flag.Parse()
+
+	auth, region, err := stretcher.LoadAWSCredentials(profile)
+	if err != nil {
+		log.Println(err)
+	}
+	fmt.Println("profile     ", profile)
+	fmt.Println("access_key  ", auth.AccessKey)
+	fmt.Println("secret_key  ", auth.SecretKey)
+	fmt.Println("region      ", region.Name)
+}

--- a/stretcher.go
+++ b/stretcher.go
@@ -28,20 +28,10 @@ func Init() {
 func Run() error {
 	log.Println("Starting up stretcher agent")
 
-	profile := os.Getenv("AWS_DEFAULT_PROFILE")
-	if profile == "" {
-		profile = AWSDefaultProfileName
-	}
-	if file := os.Getenv("AWS_CONFIG_FILE"); file != "" {
-		err := LoadAWSConfigFile(file, profile)
-		if err != nil {
-			return fmt.Errorf("Load AWS_CONFIG_FILE failed: %s", err)
-		}
-	} else {
-		LoadAWSAuthFromIAMRole()
-	}
-	if region := os.Getenv("AWS_DEFAULT_REGION"); region != "" {
-		AWSRegion = aws.GetRegion(region)
+	var err error
+	AWSAuth, AWSRegion, err = LoadAWSCredentials("")
+	if err != nil {
+		return err
 	}
 
 	payload, err := parseEvents()

--- a/stretcher.go
+++ b/stretcher.go
@@ -33,6 +33,8 @@ func Run() error {
 	if err != nil {
 		return err
 	}
+	log.Println("region:", AWSRegion.Name)
+	log.Println("aws_access_key_id:", AWSAuth.AccessKey)
 
 	payload, err := parseEvents()
 	if err != nil {

--- a/test/.aws/config
+++ b/test/.aws/config
@@ -1,0 +1,9 @@
+[default]
+region = ap-northeast-1
+aws_access_key_id = default_key
+aws_secret_access_key = default_secret
+
+[profile bar]
+region = ap-southeast-1
+aws_access_key_id = bar_key
+aws_secret_access_key = bar_secret

--- a/test/.aws/credentials
+++ b/test/.aws/credentials
@@ -1,0 +1,4 @@
+[foo]
+region = us-west-2
+aws_access_key_id = foo_key
+aws_secret_access_key = foo_secret


### PR DESCRIPTION
More compatible with aws-cli for loading credentials.

1. Load credentials from ~/.aws/config, ~/.aws/credentials (override by AWS_CONFIG_FILE)
2. Override it by env AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY.
3. Otherwise, try use IAM Role.
