### PR TITLE
Introduce SyncStrategy and enable to deploy sources via `mv`

### DIFF
--- a/manifest.go
+++ b/manifest.go
@@ -20,7 +20,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-var RsyncDefaultOpts = []string{"-av", "--delete"}
 var DefaultDestMode = os.FileMode(0755)
 
 type Manifest struct {
@@ -120,23 +119,8 @@ func (m *Manifest) Deploy(conf Config) error {
 		to = to + "/"
 	}
 
-	args := []string{}
-	args = append(args, RsyncDefaultOpts...)
-	if m.ExcludeFrom != "" {
-		args = append(args, "--exclude-from", from+m.ExcludeFrom)
-	}
-	if len(m.Excludes) > 0 {
-		for _, ex := range m.Excludes {
-			args = append(args, "--exclude", ex)
-		}
-	}
-	args = append(args, from, to)
-
-	log.Println("rsync", args)
-	out, err = exec.Command("rsync", args...).CombinedOutput()
-	if len(out) > 0 {
-		log.Println(string(out))
-	}
+	strategy := &RsyncStrategy{Manifest: m}
+	err = strategy.Sync(from, to)
 	if err != nil {
 		return err
 	}

--- a/manifest.go
+++ b/manifest.go
@@ -114,10 +114,6 @@ func (m *Manifest) Deploy(conf Config) error {
 
 	from := dir + "/"
 	to := m.Dest
-	// append "/" when not terminated by "/"
-	if strings.LastIndex(to, "/") != len(to)-1 {
-		to = to + "/"
-	}
 
 	strategy := &RsyncStrategy{Manifest: m}
 	err = strategy.Sync(from, to)

--- a/manifest.go
+++ b/manifest.go
@@ -23,13 +23,14 @@ import (
 var DefaultDestMode = os.FileMode(0755)
 
 type Manifest struct {
-	Src         string       `yaml:"src"`
-	CheckSum    string       `yaml:"checksum"`
-	Dest        string       `yaml:"dest"`
-	DestMode    *os.FileMode `yaml:"dest_mode"`
-	Commands    Commands     `yaml:"commands"`
-	Excludes    []string     `yaml:"excludes"`
-	ExcludeFrom string       `yaml:"exclude_from"`
+	Src          string       `yaml:"src"`
+	CheckSum     string       `yaml:"checksum"`
+	Dest         string       `yaml:"dest"`
+	DestMode     *os.FileMode `yaml:"dest_mode"`
+	Commands     Commands     `yaml:"commands"`
+	Excludes     []string     `yaml:"excludes"`
+	ExcludeFrom  string       `yaml:"exclude_from"`
+	SyncStrategy string       `yaml:"sync_strategy"`
 }
 
 func (m *Manifest) newHash() (hash.Hash, error) {
@@ -115,7 +116,11 @@ func (m *Manifest) Deploy(conf Config) error {
 	from := dir + "/"
 	to := m.Dest
 
-	strategy := &RsyncStrategy{Manifest: m}
+	strategy, err := NewSyncStrategy(m)
+	if err != nil {
+		return err
+	}
+
 	err = strategy.Sync(from, to)
 	if err != nil {
 		return err

--- a/sync_strategy.go
+++ b/sync_strategy.go
@@ -1,0 +1,43 @@
+package stretcher
+
+import (
+	"log"
+	"os/exec"
+)
+
+type SyncStrategy interface {
+	Sync(from, to string) error
+}
+
+type RsyncStrategy struct {
+	*Manifest
+}
+
+var RsyncDefaultOpts = []string{"-av", "--delete"}
+
+func (s *RsyncStrategy) Sync(from, to string) error {
+	m := s.Manifest
+
+	args := []string{}
+	args = append(args, RsyncDefaultOpts...)
+	if m.ExcludeFrom != "" {
+		args = append(args, "--exclude-from", from+m.ExcludeFrom)
+	}
+	if len(m.Excludes) > 0 {
+		for _, ex := range m.Excludes {
+			args = append(args, "--exclude", ex)
+		}
+	}
+	args = append(args, from, to)
+
+	log.Println("rsync", args)
+	out, err := exec.Command("rsync", args...).CombinedOutput()
+	if len(out) > 0 {
+		log.Println(string(out))
+	}
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/sync_strategy.go
+++ b/sync_strategy.go
@@ -1,6 +1,7 @@
 package stretcher
 
 import (
+	"fmt"
 	"log"
 	"os"
 	"os/exec"
@@ -16,6 +17,20 @@ type RsyncStrategy struct {
 }
 
 var RsyncDefaultOpts = []string{"-av", "--delete"}
+
+func NewSyncStrategy(m *Manifest) (SyncStrategy, error) {
+	switch m.SyncStrategy {
+	case "":
+		// default to Rsync
+		return &RsyncStrategy{Manifest: m}, nil
+	case "rsync":
+		return &RsyncStrategy{Manifest: m}, nil
+	case "mv":
+		return &MvSyncStrategy{}, nil
+	default:
+		return nil, fmt.Errorf("Invalid strategy name: %s", m.SyncStrategy)
+	}
+}
 
 func (s *RsyncStrategy) Sync(from, to string) error {
 	m := s.Manifest

--- a/sync_strategy.go
+++ b/sync_strategy.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 )
 
 type SyncStrategy interface {
@@ -18,6 +19,11 @@ var RsyncDefaultOpts = []string{"-av", "--delete"}
 
 func (s *RsyncStrategy) Sync(from, to string) error {
 	m := s.Manifest
+
+	// append "/" when not terminated by "/"
+	if strings.LastIndex(to, "/") != len(to)-1 {
+		to = to + "/"
+	}
 
 	args := []string{}
 	args = append(args, RsyncDefaultOpts...)

--- a/sync_strategy.go
+++ b/sync_strategy.go
@@ -2,6 +2,7 @@ package stretcher
 
 import (
 	"log"
+	"os"
 	"os/exec"
 )
 
@@ -40,4 +41,12 @@ func (s *RsyncStrategy) Sync(from, to string) error {
 	}
 
 	return nil
+}
+
+type MvSyncStrategy struct {
+}
+
+func (s *MvSyncStrategy) Sync(from, to string) error {
+	log.Printf("Rename srcdir %s to dest %s\n", from, to)
+	return os.Rename(from, to)
 }


### PR DESCRIPTION
Hi, thanks for great middleware :)

I have been using stretcher with [capistrano-stretcher](https://github.com/pepabo/capistrano-stretcher), 
but with this deploy recipe stretcher is always creating new directory with rsync, which is unintendedly waists target servers' CPU, disk IO, and so on...

I'm very happy and excited when stretcher is able to deploy sources via mv(`rename(2)`) following the manifest option `sync_strategy`.

I'm welcoming if you have any thoughts on that.
