### PR TITLE
Run commands only

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ tar and rsync must be exist in PATH environment.
 If you use stretcher under systemd, You can see unfinished stdout with journald.
 You should add `RateLimitBurst=0` into `/etc/systemd/journald.conf` for getting stdout completely.
 
+## Commands execution only mode
+
+If `src` is not defined in a manifest, Stretcher runs `pre`/`post` and `success`/`failure` commands simply.
+
 ## LICENSE
 
 The MIT License (MIT)

--- a/manifest_test.go
+++ b/manifest_test.go
@@ -432,3 +432,43 @@ dest: ` + testDest + `
 		t.Error("elapsed expecct abount 2 sec. but %s", elapsed)
 	}
 }
+
+func TestDeployCommandsSuccess(t *testing.T) {
+	yml := `
+commands:
+  pre:
+    - 'echo "pre 1"'
+    - 'echo "pre 2"'
+  post:
+    - 'echo "post 1"'
+    - 'echo "post 2"'
+`
+	m, err := stretcher.ParseManifest([]byte(yml))
+	if err != nil {
+		t.Error(err)
+	}
+	err = m.Deploy(stretcher.Config{})
+	if err != nil {
+		t.Error(err)
+	}
+}
+
+func TestDeployCommandsFail(t *testing.T) {
+	yml := `
+commands:
+  pre:
+    - 'echo "pre 1"'
+    - exit 1
+  post:
+    - 'echo "post 1"'
+    - 'echo "post 2"'
+`
+	m, err := stretcher.ParseManifest([]byte(yml))
+	if err != nil {
+		t.Error(err)
+	}
+	err = m.Deploy(stretcher.Config{})
+	if err == nil {
+		t.Error(err)
+	}
+}


### PR DESCRIPTION
If `src` is not defined in a manifest, Stretcher runs `pre`/`post` and `success`/`failure` commands simply.
