### PR TITLE
select rsync verbose by option

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ Usage of stretcher:
         retry count for download src archives
   -retry-wait int
         wait for retry download src archives (sec) (default 3)
+  -rsync-verbose string
+        rsync verbose option (default -v)
   -timeout int
         timeout for download src archives (sec)
   -v    show version

--- a/cmd/stretcher/main.go
+++ b/cmd/stretcher/main.go
@@ -26,6 +26,7 @@ func main() {
 		timeout      int64
 		retry        int
 		retryWait    int64
+		rsyncVerbose string
 	)
 	flag.BoolVar(&showVersion, "v", false, "show version")
 	flag.BoolVar(&showVersion, "version", false, "show version")
@@ -34,6 +35,7 @@ func main() {
 	flag.Int64Var(&timeout, "timeout", 0, "timeout for download src archives (sec)")
 	flag.IntVar(&retry, "retry", 0, "retry count for download src archives")
 	flag.Int64Var(&retryWait, "retry-wait", 3, "wait for retry download src archives (sec)")
+	flag.StringVar(&rsyncVerbose, "rsync-verbose", "-v", "rsync verbose revel default -v")
 	flag.Parse()
 
 	if showVersion {
@@ -56,6 +58,11 @@ func main() {
 		} else {
 			conf.MaxBandWidth = bw
 		}
+	}
+
+	if err := stretcher.SetRsyncVerboseOpt(rsyncVerbose); err != nil {
+		fmt.Println("Cannot set -rsync-verbose", err)
+		os.Exit(1)
 	}
 
 	log.Println("stretcher version:", version)

--- a/sync_strategy.go
+++ b/sync_strategy.go
@@ -16,7 +16,20 @@ type RsyncStrategy struct {
 	*Manifest
 }
 
-var RsyncDefaultOpts = []string{"-av", "--delete"}
+var (
+	RsyncDefaultOpts = []string{"-a", "--delete"}
+	RsyncVerboseOpt  = "-v"
+)
+
+func SetRsyncVerboseOpt(opt string) error {
+	switch opt {
+	case "", "-v", "-vv", "-vvv":
+		RsyncVerboseOpt = opt
+		return nil
+	default:
+		return fmt.Errorf("invalid rsync verbose option: %s", opt)
+	}
+}
 
 func NewSyncStrategy(m *Manifest) (SyncStrategy, error) {
 	switch m.SyncStrategy {
@@ -40,6 +53,7 @@ func (s *RsyncStrategy) Sync(from, to string) error {
 
 	args := []string{}
 	args = append(args, RsyncDefaultOpts...)
+	args = append(args, RsyncVerboseOpt)
 	if m.ExcludeFrom != "" {
 		args = append(args, "--exclude-from", from+m.ExcludeFrom)
 	}


### PR DESCRIPTION
rsync log is too long when initial deploy.

I using stretcher with consul-kv-dashboard. consul kv store cannot be larger than 512kb, therefore sometimes fail put kv store in post process.

`-rsync-verbose` option control rsync verbosity.
stretcher not set rsync `-v` option, when `-rsync-verbose ""`. Conversely, If you need more verbosity, set `-rsync-verbose "-vvv"`.