### PR TITLE
fix parseEvents()

### DIFF
--- a/stretcher.go
+++ b/stretcher.go
@@ -193,6 +193,10 @@ func parseEvents() (string, error) {
 		}
 		// event passed by stdin (raw string)
 		line, err := reader.ReadString('\n')
+		if err == io.EOF {
+			// ignore EOF when the input has not LF.
+			err = nil
+		}
 		return strings.Trim(line, "\n"), err
 	}
 }


### PR DESCRIPTION
Accept an input which has not LF.

e.g.
```console
$ echo -n file://path/to/manifest | stretcher
```
Following error had been occured in older versions.
> Could not parse event: EOF