### PR TITLE
add --http-headers option.

### DIFF
--- a/http.go
+++ b/http.go
@@ -1,6 +1,5 @@
 package stretcher
 
 type HTTPOptions struct {
-	Headers  map[string]string `yaml:"headers"`
-	RetryMax int               `yaml:"retry_max"`
+	Headers map[string]string `help:"HTTP request headers(key=value) for download src archives with HTTP or HTTPS"`
 }

--- a/manifest.go
+++ b/manifest.go
@@ -155,13 +155,13 @@ func (m *Manifest) Deploy(ctx context.Context, conf *Config) error {
 
 func (m *Manifest) fetchSrc(ctx context.Context, conf *Config, tmp *os.File) error {
 	begin := time.Now()
-	src, err := getURL(ctx, m.Src)
+	src, err := getURL(ctx, m.Src, conf)
 	if err != nil {
 		for i := 0; i < conf.Retry; i++ {
 			log.Printf("Get src failed: %s", err)
 			log.Printf("Try again. Waiting: %s", conf.RetryWait)
 			time.Sleep(conf.RetryWait)
-			src, err = getURL(ctx, m.Src)
+			src, err = getURL(ctx, m.Src, conf)
 			if err == nil {
 				break
 			}


### PR DESCRIPTION
This pull request introduces several changes to enhance the HTTP configuration and handling in the `stretcher` package. The main updates include adding support for custom HTTP headers and passing configuration options to various functions.

### Enhancements to HTTP configuration and handling:

* [`http.go`](diffhunk://#diff-6971e2713fe98b79ea18e9748bf68928f6ebcd4d93e7a27f10e7472ce6d78a48L4-R4): Modified the `HTTPOptions` struct to include a help description for the `Headers` field.

* [`stretcher.go`](diffhunk://#diff-ec61529af5c65e89530b34abf4d7effd937286f823a4c8bdbd3aebd8f4e3e837R39): Added the `HTTPOptions` struct to the `Config` struct to embed HTTP configuration options.

### Updates to function signatures to include configuration options:

* [`stretcher.go`](diffhunk://#diff-ec61529af5c65e89530b34abf4d7effd937286f823a4c8bdbd3aebd8f4e3e837L147-R156): Updated the `getHTTP` function to accept an `HTTPOptions` parameter and added logic to include custom headers in HTTP requests. [[1]](diffhunk://#diff-ec61529af5c65e89530b34abf4d7effd937286f823a4c8bdbd3aebd8f4e3e837L147-R156) [[2]](diffhunk://#diff-ec61529af5c65e89530b34abf4d7effd937286f823a4c8bdbd3aebd8f4e3e837L161-R165)

* [`stretcher.go`](diffhunk://#diff-ec61529af5c65e89530b34abf4d7effd937286f823a4c8bdbd3aebd8f4e3e837L173-R186): Modified the `getURL` function to accept a `Config` parameter and updated its calls to pass the configuration.

* [`manifest.go`](diffhunk://#diff-38eb3f59db4465ececb0383180bd63ac327f405b5459e7e87a59702fce293dc8L158-R164): Updated the `fetchSrc` function to pass the `Config` parameter to the `getURL` function.

* [`stretcher.go`](diffhunk://#diff-ec61529af5c65e89530b34abf4d7effd937286f823a4c8bdbd3aebd8f4e3e837L89-R90): Updated the `getManifest` function to accept a `Config` parameter and pass it to the `getURL` function. [[1]](diffhunk://#diff-ec61529af5c65e89530b34abf4d7effd937286f823a4c8bdbd3aebd8f4e3e837L89-R90) [[2]](diffhunk://#diff-ec61529af5c65e89530b34abf4d7effd937286f823a4c8bdbd3aebd8f4e3e837L173-R186)